### PR TITLE
[TASK] respect preset db configuration

### DIFF
--- a/Classes/Lightwerk/SurfCaptain/Domain/Factory/DeploymentFactory.php
+++ b/Classes/Lightwerk/SurfCaptain/Domain/Factory/DeploymentFactory.php
@@ -74,11 +74,17 @@ class DeploymentFactory {
 			throw new Exception('shared Deployment to Production Context disabled');
 		}
 		$postset = array();
-		$postset['applications'][0]['options']['db']['credentialsSource'] = 'TYPO3\\CMS';
+		if (empty($preset['applications'][0]['options']['db']) === TRUE) {
+			$postset['applications'][0]['options']['db']['credentialsSource'] = 'TYPO3\\CMS';
+		}
 		$postset['applications'][0]['options']['sourceNode'] = $sourcePreset['applications'][0]['nodes'][0];
 		$postset['applications'][0]['options']['sourceNodeOptions']['deploymentPath'] = $sourcePreset['applications'][0]['options']['deploymentPath'];
 		$postset['applications'][0]['options']['sourceNodeOptions']['context'] = $sourcePreset['applications'][0]['options']['context'];
-		$postset['applications'][0]['options']['sourceNodeOptions']['db']['credentialsSource'] = 'TYPO3\\CMS';
+		if (empty($sourcePreset['applications'][0]['options']['db']) === TRUE) {
+			$postset['applications'][0]['options']['sourceNodeOptions']['db']['credentialsSource'] = 'TYPO3\\CMS';
+		} else {
+			$postset['applications'][0]['options']['sourceNodeOptions']['db'] = $sourcePreset['applications'][0]['options']['db'];
+		}
 		$postset['applications'][0]['type'] = 'TYPO3\\CMS\\Shared';
 		$configuration = \TYPO3\Flow\Utility\Arrays::arrayMergeRecursiveOverrule($preset, $postset);
 		return $this->createFromConfiguration($configuration);


### PR DESCRIPTION
respect preset db configuration

damit kann man jetzt beliebige Folder und beliebige DBs syncen (und somit einige "spezial-Kunden"
abdecken). Fallback/Default bleibt db.credentials = TYPO3\CMS und SharedPath aus fileadmin-Link

ist das so in Deinem Sinne @lars85 ?

    "test1": {
        "applications": [
            {
                "options": {
                    "repositoryUrl": "git@github.com:achimfritz\/typo3cms.git",
                    "deploymentPath": "egal",
                    "context": "Production",
                    "db": {
                        "database": "f3_t2",
                        "password": "dev",
                        "user": "dev",
                        "host": "localhost"
                    }
                },
                "nodes": [
                    {
                        "name": "test1",
                        "sharedPath": "/tmp/test1",
                        "hostname": "localhost",
                        "username": "af"
                    }
                ]
            }
        ]
    },
    "test2": {
        "applications": [
            {
                "options": {
                    "repositoryUrl": "git@github.com:achimfritz\/typo3cms.git",
                    "deploymentPath": "egal",
                    "context": "Development",
                    "db": {
                        "database": "f3_test_db",
                        "password": "dev",
                        "user": "dev",
                        "host": "localhost"
                    }
                },
                "nodes": [
                    {
                        "name": "test2",
                        "sharedPath": "/tmp/test2",
                        "hostname": "localhost",
                        "username": "af"
                    }
                ]
            }
        ]
    },
